### PR TITLE
Add logging for sensible data of HttpClient

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,9 @@ dotnet_style_object_initializer = true:suggestion
 # Disbale rule CA1812 because the related classes are registered at the IoC-Container of Asp.Net Core
 dotnet_diagnostic.CA1812.severity = none
 
+# Disbale rule CA1848
+dotnet_diagnostic.CA1848.severity = none
+
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/src/Common/Http/Delegates/LoggingDelegate.cs
+++ b/src/Common/Http/Delegates/LoggingDelegate.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace SimpleOAuth2Client.AspNetCore.Common.Http.Delegates;
+
+/// <summary>
+/// This class logs HTTP related information.
+/// </summary>
+/// <remarks>Logs all information related HttpRequestMessage and HttpResponseMessage objects.</remarks>
+internal sealed class LoggingDelegate : DelegatingHandler
+{
+    private readonly ILogger<LoggingDelegate> _logger;
+
+    /// <summary>
+    /// The constructor.
+    /// </summary>
+    /// <param name="logger">The logger instance for this class.</param>
+    /// <exception cref="ArgumentNullException">If one of the parameter is null.</exception>
+    public LoggingDelegate(ILogger<LoggingDelegate> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        await LogHttpRequestMessage(request);
+
+        HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+
+        await LogHttpResponseMessage(response);
+
+        return response;
+    }
+
+    private async Task LogHttpRequestMessage(HttpRequestMessage httpRequestMessage)
+    {
+        _logger.LogInformation(HttpClientLogEvents.HttpRequestMessage, "HTTP-Request General Information: {Request}", httpRequestMessage);
+
+        if (httpRequestMessage.Content is not null)
+        {
+            string content = await httpRequestMessage.Content.ReadAsStringAsync();
+            _logger.LogInformation(HttpClientLogEvents.HttpRequestMessage, "HTTP-Request Content: {Content}", content);
+        }
+    }
+
+    private async Task LogHttpResponseMessage(HttpResponseMessage httpResponseMessage)
+    {
+        _logger.LogInformation(HttpClientLogEvents.HttpResponseMessage, "HTTP-Response General Information: {Response}", httpResponseMessage);
+
+        string content = await httpResponseMessage.Content.ReadAsStringAsync();
+        if (!string.IsNullOrEmpty(content))
+        {
+            _logger.LogInformation(HttpClientLogEvents.HttpResponseMessage, "HTTP-Response Content: {Content}", content);
+        }
+    }
+
+    /// <summary>
+    /// EventId's for logging.
+    /// </summary>
+    private static class HttpClientLogEvents
+    {
+        /// <summary>
+        /// EventId for HttpRequestMessage.
+        /// </summary>
+        public const int HttpRequestMessage = 1000;
+
+        /// <summary>
+        /// EventId for HttpRepsoneMessage.
+        /// </summary>
+        public const int HttpResponseMessage = 1001;
+    }
+}

--- a/src/Common/Http/Delegates/TransientErrorHandlerDelegate.cs
+++ b/src/Common/Http/Delegates/TransientErrorHandlerDelegate.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using Polly.Timeout;
 
-namespace SimpleOAuth2Client.AspNetCore.Common.Http;
+namespace SimpleOAuth2Client.AspNetCore.Common.Http.Delegates;
 
 /// <summary>
 /// This class handles exceptions which are related to transient network errors.

--- a/src/Common/Http/Extensions/CustomizedHttpClientServiceCollectionExtensions.cs
+++ b/src/Common/Http/Extensions/CustomizedHttpClientServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Polly.Contrib.WaitAndRetry;
 using Polly.Extensions.Http;
 using Polly.Retry;
 using Polly.Timeout;
+using SimpleOAuth2Client.AspNetCore.Common.Http.Delegates;
 using SimpleOAuth2Client.AspNetCore.Options;
 
 namespace SimpleOAuth2Client.AspNetCore.Common.Http.Extensions;
@@ -36,20 +37,82 @@ internal static class CustomizedHttpClientServiceCollectionExtensions
             .GetRequiredService<IOptionsMonitor<SimpleOAuth2ClientOptions>>()
             .CurrentValue;
 
-        IHttpClientBuilder httpClientBuilder = services
+        services
             .AddHttpClient("AuthClient", httpClient =>
             {
                 httpClient.DefaultRequestHeaders.Clear();
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/x-www-form-urlencoded");
-            });
+            })
+            .HandleServerCertificateValidation(options)
+            .AddHttpMessageHandler<TransientErrorHandlerDelegate>()
+            .AddHttpClientLogging(services, options)
+            .AddCustomizedHttpClientPolicies(options);
 
+        return services;
+    }
+
+    /// <summary>
+    /// Add Polly based customized HttpClient policies.
+    /// </summary>
+    /// <param name="httpClientBuilder">The HttpClientBuilder to modify the named HttpClient.</param>
+    /// <param name="options">The SimpleOAuth2Client options.</param>
+    /// <returns>The modified HttpClientBuilder.</returns>
+    private static IHttpClientBuilder AddCustomizedHttpClientPolicies(this IHttpClientBuilder httpClientBuilder, SimpleOAuth2ClientOptions options)
+    {
+        int timeoutPerRetry = options.RetryOptions.TimeoutPerRetry;
+
+        // Define a timeout policy per request of 10 seconds
+        AsyncTimeoutPolicy<HttpResponseMessage> timeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(timeoutPerRetry);
+
+        int firstRetryDelay = options.RetryOptions.FirstRetryDelay;
+        int retryAttempts = options.RetryOptions.RetryAttempts;
+
+        // Define a retry policy
+        AsyncRetryPolicy<HttpResponseMessage> retryPolicy = HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .Or<TimeoutRejectedException>()
+            .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(firstRetryDelay), retryAttempts));
+
+        httpClientBuilder
+            .AddPolicyHandler(retryPolicy)
+            .AddPolicyHandler(timeoutPolicy);
+
+        return httpClientBuilder;
+    }
+
+    /// <summary>
+    /// Add logging to HttpClient if configured.
+    /// </summary>
+    /// <param name="httpClientBuilder">The HttpClientBuilder to modify the named HttpClient.</param>
+    /// <param name="services">The service collection to which customized HttpClient is added.</param>
+    /// <param name="options">The SimpleOAuth2Client options.</param>
+    /// <returns>The modified HttpClientBuilder.</returns>
+    private static IHttpClientBuilder AddHttpClientLogging(this IHttpClientBuilder httpClientBuilder, IServiceCollection services, SimpleOAuth2ClientOptions options)
+    {
+        if (options.EnableSensibleHttpClientLogging)
+        {
+            services.TryAddScoped<LoggingDelegate>();
+            httpClientBuilder.AddHttpMessageHandler<LoggingDelegate>();
+        }
+
+        return httpClientBuilder;
+    }
+
+    /// <summary>
+    /// Handle the server certificate validation process.
+    /// </summary>
+    /// <param name="httpClientBuilder">The HttpClientBuilder to modify the named HttpClient.</param>
+    /// <param name="options">The SimpleOAuth2Client options.</param>
+    /// <returns>The modified HttpClientBuilder.</returns>
+    private static IHttpClientBuilder HandleServerCertificateValidation(this IHttpClientBuilder httpClientBuilder, SimpleOAuth2ClientOptions options)
+    {
         if (options.DisableServerCertificateValidation)
         {
             static bool DisableCertificateValidation(HttpRequestMessage _1, X509Certificate2? _2, X509Chain? _3, SslPolicyErrors _4)
                 => true;
 
-            httpClientBuilder = httpClientBuilder
+            httpClientBuilder
                 .ConfigureHttpMessageHandlerBuilder(builder => builder.PrimaryHandler = new HttpClientHandler
                 {
                     // ############################################################################################################
@@ -67,39 +130,6 @@ internal static class CustomizedHttpClientServiceCollectionExtensions
                 });
         }
 
-        httpClientBuilder
-            .AddHttpMessageHandler<TransientErrorHandlerDelegate>()
-            .AddCustomizedHttpClientPolicies(options);
-
-        return services;
-    }
-
-    /// <summary>
-    /// Add Polly based customized HttpClient policies.
-    /// </summary>
-    /// <param name="httpClient">The HttpClientBuilder to modify the named HttpClient.</param>
-    /// <param name="options">The SimpleOAuth2Client options.</param>
-    /// <returns>The modified HttpClientBuilder.</returns>
-    private static IHttpClientBuilder AddCustomizedHttpClientPolicies(this IHttpClientBuilder httpClient, SimpleOAuth2ClientOptions options)
-    {
-        int timeoutPerRetry = options.RetryOptions.TimeoutPerRetry;
-
-        // Define a timeout policy per request of 10 seconds
-        AsyncTimeoutPolicy<HttpResponseMessage> timeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(timeoutPerRetry);
-
-        int firstRetryDelay = options.RetryOptions.FirstRetryDelay;
-        int retryAttempts = options.RetryOptions.RetryAttempts;
-
-        // Define a retry policy
-        AsyncRetryPolicy<HttpResponseMessage> retryPolicy = HttpPolicyExtensions
-            .HandleTransientHttpError()
-            .Or<TimeoutRejectedException>()
-            .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(firstRetryDelay), retryAttempts));
-
-        httpClient
-            .AddPolicyHandler(retryPolicy)
-            .AddPolicyHandler(timeoutPolicy);
-
-        return httpClient;
+        return httpClientBuilder;
     }
 }

--- a/src/Options/SimpleOAuth2ClientOptions.cs
+++ b/src/Options/SimpleOAuth2ClientOptions.cs
@@ -20,4 +20,9 @@ public sealed record SimpleOAuth2ClientOptions
     /// </summary>
     /// <remarks>The default value is false. Be careful with this option. Can be lead to a security issue.</remarks>
     public bool DisableServerCertificateValidation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the options to enable logs from HttpClient.
+    /// </summary>
+    public bool EnableSensibleHttpClientLogging { get; set; }
 }

--- a/src/SimpleOAuth2Client.AspNetCore.csproj
+++ b/src/SimpleOAuth2Client.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>

--- a/tests/Tests/GrantTypes/ClientCredential/ClientCredentialsTests.cs
+++ b/tests/Tests/GrantTypes/ClientCredential/ClientCredentialsTests.cs
@@ -44,7 +44,7 @@ public class ClientCredentialsTests
         using HttpContent accessTokenResponse = AuthorizationServerResponses.CreateAccessTokenResponse(accessToken, tokenType, expiresIn);
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.OK, accessTokenResponse);
 
         validatorMock
@@ -106,10 +106,8 @@ public class ClientCredentialsTests
         using HttpContent accessTokenResponse = AuthorizationServerResponses.CreateAccessTokenResponse(accessToken, tokenType, expiresIn);
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.OK, accessTokenResponse);
-
-        // TBD: Setup validator
 
         // When
         Result<AccessToken, OAuth2Error> accessTokenResult = await sut.Execute();
@@ -152,7 +150,7 @@ public class ClientCredentialsTests
         using HttpContent accessTokenResponse = AuthorizationServerResponses.CreateAccessTokenResponseWithNullValue();
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.OK, accessTokenResponse);
 
         // When
@@ -198,7 +196,7 @@ public class ClientCredentialsTests
         SetupSimpleOAuth2ClientOptions(optionsMonitorMock, options);
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.BadRequest, httpResponseContent);
 
         // When
@@ -240,7 +238,7 @@ public class ClientCredentialsTests
         SetupSimpleOAuth2ClientOptions(optionsMonitorMock, options);
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.BadRequest, httpResponseContent);
 
         // When
@@ -280,7 +278,7 @@ public class ClientCredentialsTests
         SetupSimpleOAuth2ClientOptions(optionsMonitorMock, options);
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.BadRequest, httpResponseContent);
 
         // When
@@ -321,7 +319,7 @@ public class ClientCredentialsTests
         SetupSimpleOAuth2ClientOptions(optionsMonitorMock, options);
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.InternalServerError, accessTokenResponse);
 
         // When
@@ -362,7 +360,7 @@ public class ClientCredentialsTests
         SetupSimpleOAuth2ClientOptions(optionsMonitorMock, options);
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.BadGateway, accessTokenResponse);
 
         // When
@@ -401,7 +399,7 @@ public class ClientCredentialsTests
         SetupSimpleOAuth2ClientOptions(optionsMonitorMock, options);
 
         httpMessageHandlerMock
-            .When(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
+            .Expect(HttpMethod.Post, options.ClientCredentialOptions.TokenEndpoint.ToString())
             .Respond(HttpStatusCode.Unauthorized);
 
         // When

--- a/tests/Tests/Http/BasicAuthenticationHeaderValueTests.cs
+++ b/tests/Tests/Http/BasicAuthenticationHeaderValueTests.cs
@@ -16,6 +16,7 @@ public class BasicAuthenticationHeaderValueTests
         string password)
     {
         // Given
+        // Nothing to do --> Test data will be injected (See: AutoData attribute)
 
         // When
         var basicAuthenticationHeaderValue = new BasicAuthenticationHeaderValue(username, password);

--- a/tests/Tests/Http/LoggingDelegateTests.cs
+++ b/tests/Tests/Http/LoggingDelegateTests.cs
@@ -1,0 +1,152 @@
+﻿using System.Net;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RichardSzalay.MockHttp;
+using SimpleOAuth2Client.AspNetCore.Common.Http.Delegates;
+using SimpleOAuth2Client.AspNetCore.UnitTests.Common.Attributes;
+using Xunit;
+
+namespace SimpleOAuth2Client.AspNetCore.UnitTests.Tests.Http;
+
+public class LoggingDelegateTests
+{
+    private const int HttpRequestMessageEventId = 1000;
+    private const int HttpResponseMessageEventId = 1001;
+
+    [UnitTest]
+    [Theory]
+    [AutoMoqData]
+    internal void GivenAllArgumentsAreValid_WhenLoggingDelegateIsCreated_ThenNoArgumentNullExceptionIsThrown(
+        Mock<ILogger<LoggingDelegate>> loggerMock)
+    {
+        // Given
+        // Nothing to do --> Test data will be injected (See: AutoData attribute)
+
+        // When
+        Action sutCreated = () => _ = new LoggingDelegate(loggerMock.Object);
+
+        // Then
+        sutCreated
+            .Should()
+            .NotThrow<ArgumentNullException>();
+    }
+
+    [UnitTest]
+    [Theory]
+    [AutoData]
+    internal async Task GivenHttpRequestAndResponseMessageHasContent_WhenPostAsyncIsCalled_ThenLogMethodForHttpRequestMessageIsCalledTwoTimesAndLogMethodForHttpResponseMessageeIsCalledTwoTimes(
+        Uri uri,
+        StringContent requestContent,
+        StringContent responseContent,
+        MockHttpMessageHandler httpMessageHandlerMock,
+        Mock<ILogger<LoggingDelegate>> loggerMock)
+    {
+        // Given
+        httpMessageHandlerMock
+            .Expect(HttpMethod.Post, uri.ToString())
+            .Respond(HttpStatusCode.OK, responseContent);
+
+        using var loggingDelegate = new LoggingDelegate(loggerMock.Object)
+        {
+            InnerHandler = httpMessageHandlerMock
+        };
+
+        using var httpClient = new HttpClient(loggingDelegate);
+
+        // When
+        _ = await httpClient.PostAsync(uri, requestContent);
+
+        // Then
+        VerifyLogMethod(loggerMock, LogLevel.Information, HttpRequestMessageEventId, Times.Exactly(2));
+        VerifyLogMethod(loggerMock, LogLevel.Information, HttpResponseMessageEventId, Times.Exactly(2));
+    }
+
+    [UnitTest]
+    [Theory]
+    [AutoData]
+    internal async Task GivenHttpRequestMessageHasNoContent_WhenSendAsyncIsCalled_ThenLogMethodForHttpRequestMessageIsCalledOnceAndLogMethodForHttpResponseMessageIsCalledTwoTimes(
+        Uri uri,
+        StringContent requestContent,
+        MockHttpMessageHandler httpMessageHandlerMock,
+        Mock<ILogger<LoggingDelegate>> loggerMock)
+    {
+        // Given
+        httpMessageHandlerMock
+            .Expect(HttpMethod.Post, uri.ToString())
+            .Respond(HttpStatusCode.OK, requestContent);
+
+        using var loggingDelegate = new LoggingDelegate(loggerMock.Object)
+        {
+            InnerHandler = httpMessageHandlerMock
+        };
+
+        using var httpClient = new HttpClient(loggingDelegate);
+
+        using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri.ToString());
+
+        // When
+        _ = await httpClient.SendAsync(httpRequestMessage);
+
+        // Then
+        VerifyLogMethod(loggerMock, LogLevel.Information, HttpRequestMessageEventId, Times.Exactly(1));
+        VerifyLogMethod(loggerMock, LogLevel.Information, HttpResponseMessageEventId, Times.Exactly(2));
+    }
+
+    [UnitTest]
+    [Theory]
+    [AutoData]
+    internal async Task GivenHttpResponseMessageHasNoContent_WhenPostAsyncIsCalled_ThenLogMethodForHttpRequestMessageIsCalledTwoTimesAndLogMethodForHttpResponseMessageIsCalledOnce(
+        Uri uri,
+        StringContent content,
+        MockHttpMessageHandler httpMessageHandlerMock,
+        Mock<ILogger<LoggingDelegate>> loggerMock)
+    {
+        // Given
+        httpMessageHandlerMock
+            .Expect(HttpMethod.Post, uri.ToString())
+            .Respond(req => new HttpResponseMessage());
+
+        using var loggingDelegate = new LoggingDelegate(loggerMock.Object)
+        {
+            InnerHandler = httpMessageHandlerMock
+        };
+
+        using var httpClient = new HttpClient(loggingDelegate);
+
+        // When
+        _ = await httpClient.PostAsync(uri, content);
+
+        // Then
+        VerifyLogMethod(loggerMock, LogLevel.Information, HttpRequestMessageEventId, Times.Exactly(2));
+        VerifyLogMethod(loggerMock, LogLevel.Information, HttpResponseMessageEventId, Times.Exactly(1));
+    }
+
+    [UnitTest]
+    [Fact]
+    internal void GivenILoggerIsNull_WhenLoggingDelegateIsCreated_ThenArgumentNullExceptionWithCorrectrParameterIsThrown()
+    {
+        // Given
+        ILogger<LoggingDelegate> invalidLogger = null!;
+
+        // When
+        Action sutCreated = () => _ = new LoggingDelegate(invalidLogger);
+
+        // Then
+        sutCreated
+            .Should()
+            .ThrowExactly<ArgumentNullException>()
+            .WithParameterName("logger");
+    }
+
+    private static void VerifyLogMethod(Mock<ILogger<LoggingDelegate>> loggerMock, LogLevel logLevel, EventId eventId, Times times)
+    {
+        loggerMock.Verify(_ => _.Log(
+            logLevel,
+            eventId,
+            It.Is<It.IsAnyType>((v, t) => true),
+            It.IsAny<Exception>(),
+            It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)), times);
+    }
+}

--- a/tests/Tests/Http/TransientErrorHandlerDelegateTests.cs
+++ b/tests/Tests/Http/TransientErrorHandlerDelegateTests.cs
@@ -3,7 +3,7 @@ using AutoFixture.Xunit2;
 using FluentAssertions;
 using Polly.Timeout;
 using RichardSzalay.MockHttp;
-using SimpleOAuth2Client.AspNetCore.Common.Http;
+using SimpleOAuth2Client.AspNetCore.Common.Http.Delegates;
 using SimpleOAuth2Client.AspNetCore.UnitTests.Common.Attributes;
 using Xunit;
 
@@ -16,7 +16,7 @@ public class TransientErrorHandlerDelegateTests
     [AutoData]
     internal async Task GivenHttpRequestExceptionIsThrown_WhenHttpClientIsExecuted_ThenTransientErrorHandlerDelegateReturnHttpStatusCode500InternalServerError(
         Uri uri,
-        StringContent content,
+        StringContent requestContent,
         MockHttpMessageHandler httpMessageHandlerMock)
     {
         // Given
@@ -32,7 +32,7 @@ public class TransientErrorHandlerDelegateTests
         using var httpClient = new HttpClient(transientErrorHandler);
 
         // When
-        HttpResponseMessage responseMessage = await httpClient.PostAsync(uri, content);
+        HttpResponseMessage responseMessage = await httpClient.PostAsync(uri, requestContent);
 
         // Then
         responseMessage
@@ -52,7 +52,7 @@ public class TransientErrorHandlerDelegateTests
     [AutoData]
     internal void GivenInvalidOperationIsThrown_WhenHttpClientIsExecuted_ThenTransientErrorHandlerDelegateRethrowTheException(
         Uri uri,
-        StringContent content,
+        StringContent requestContent,
         string exceptionMessage,
         MockHttpMessageHandler httpMessageHandlerMock)
     {
@@ -69,7 +69,7 @@ public class TransientErrorHandlerDelegateTests
         using var httpClient = new HttpClient(transientErrorHandler);
 
         // When
-        Func<Task> postAsyncCalled = async () => _ = await httpClient.PostAsync(uri, content);
+        Func<Task> postAsyncCalled = async () => _ = await httpClient.PostAsync(uri, requestContent);
 
         // Then
         postAsyncCalled
@@ -83,7 +83,7 @@ public class TransientErrorHandlerDelegateTests
     [AutoData]
     internal async Task GivenTaskCanceledExceptionIsThrown_WhenHttpClientIsExecuted_ThenTransientErrorHandlerDelegateReturnHttpStatusCode500InternalServerError(
         Uri uri,
-        StringContent content,
+        StringContent requestContent,
         MockHttpMessageHandler httpMessageHandlerMock)
     {
         // Given
@@ -99,7 +99,7 @@ public class TransientErrorHandlerDelegateTests
         using var httpClient = new HttpClient(transientErrorHandler);
 
         // When
-        HttpResponseMessage responseMessage = await httpClient.PostAsync(uri, content);
+        HttpResponseMessage responseMessage = await httpClient.PostAsync(uri, requestContent);
 
         // Then
         responseMessage
@@ -119,7 +119,7 @@ public class TransientErrorHandlerDelegateTests
     [AutoData]
     internal async Task GivenTimeoutRejectedExceptionIsThrown_WhenHttpClientIsExecuted_ThenTransientErrorHandlerDelegateReturnHttpStatusCode500InternalServerError(
         Uri uri,
-        StringContent content,
+        StringContent requestContent,
         MockHttpMessageHandler httpMessageHandlerMock)
     {
         // Given
@@ -135,7 +135,7 @@ public class TransientErrorHandlerDelegateTests
         using var httpClient = new HttpClient(transientErrorHandler);
 
         // When
-        HttpResponseMessage responseMessage = await httpClient.PostAsync(uri, content);
+        HttpResponseMessage responseMessage = await httpClient.PostAsync(uri, requestContent);
 
         // Then
         responseMessage


### PR DESCRIPTION
## Proposed changes

With this Pull-Request I add sensible logging for .NET HttpClient. To add logging i extend the  DelegatingHandler class and add it into the customized HttpClient chain. As a result the client can see the data from AccessTokenRequest and AccessTokenResponse. The log level is set Information.

## Types of changes

What types of changes does your code introduce to SimpleOAuth2Client.AspNetCore?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Unit tests pass locally with my changes
- [x] No new code warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments needed.
