### PR TITLE
Log handled exceptions inside the HttpClient execution chain

### DIFF
--- a/src/Common/Http/Delegates/TransientErrorHandlerDelegate.cs
+++ b/src/Common/Http/Delegates/TransientErrorHandlerDelegate.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using Microsoft.Extensions.Logging;
 using Polly.Timeout;
 
 namespace SimpleOAuth2Client.AspNetCore.Common.Http.Delegates;
@@ -8,6 +9,18 @@ namespace SimpleOAuth2Client.AspNetCore.Common.Http.Delegates;
 /// </summary>
 internal sealed class TransientErrorHandlerDelegate : DelegatingHandler
 {
+    private readonly ILogger<TransientErrorHandlerDelegate> _logger;
+
+    /// <summary>
+    /// The constructor.
+    /// </summary>
+    /// <param name="logger">The logger instance for this class.</param>
+    /// <exception cref="ArgumentNullException">If one of the parameter is null.</exception>
+    public TransientErrorHandlerDelegate(ILogger<TransientErrorHandlerDelegate> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
     /// <inheritdoc/>
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
@@ -17,10 +30,23 @@ internal sealed class TransientErrorHandlerDelegate : DelegatingHandler
         }
         catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException || ex is TimeoutRejectedException)
         {
+            _logger.LogError(HttpClientLogEvents.SendAsync, ex, "A exception was thrown within the HttpClient execution chain.");
+
             return new HttpResponseMessage(HttpStatusCode.InternalServerError)
             {
                 Content = new StringContent("The authorization server is currently not available.")
             };
         }
+    }
+
+    /// <summary>
+    /// EventId's for logging.
+    /// </summary>
+    private static class HttpClientLogEvents
+    {
+        /// <summary>
+        /// EventId for SendAsync.
+        /// </summary>
+        public const int SendAsync = 1002;
     }
 }


### PR DESCRIPTION
## Proposed changes

At the moment a client see only the generic error message that the connection to the authorization is currently not available. This message don't include the reason why the connection is currently not available. As a result the TransientErrorHandlerDelegate log the handled exception with LogLevel error to the registered LoggingProviders.

## Types of changes

What types of changes does your code introduce to SimpleOAuth2Client.AspNetCore?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Unit tests pass locally with my changes
- [x] No new code warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No further comments needed.
